### PR TITLE
Add support for contamination ratio

### DIFF
--- a/tglc/aperture_light_curve.py
+++ b/tglc/aperture_light_curve.py
@@ -135,6 +135,9 @@ class ApertureLightCurve(TimeSeries):
                 aperture_group.attrs["localbackground"] = self.meta[
                     f"{aperture_name.lower()}_aperture_local_background"
                 ]
+                aperture_group.attrs["contaminationratio"] = self.meta[
+                    f"{aperture_name.lower()}_aperture_contamination_ratio"
+                ]
 
                 aperture_data = self[f"{aperture_name.lower()}_aperture_magnitude"]
                 aperture_group.create_dataset("RawMagnitude", data=aperture_data, dtype=np.float64)


### PR DESCRIPTION
Implements #6 mostly following the approach outlined in that issue. The only difference is that the issue suggests returning the field star flux for each frame from `get_cutout_for_light_curve`, and then averaging in the photometry function, whereas I opted to return the average field star flux over all frames from `get_cutout_for_light_curve`, which makes the photometry a little simpler. This also avoids using unnecessary memory to store the field star flux for all frames when the average is all that is needed.

To Do:
- [ ] Update aperture photometry tests
- [ ] Add aperture light curve tests and check for `contaminationratio` attribute on photometry datasets