### PR TITLE
Add year 8 sector/orbit mapping

### DIFF
--- a/tests/test_utils/test_constants.py
+++ b/tests/test_utils/test_constants.py
@@ -68,11 +68,21 @@ def test_get_sector_containing_orbit():
     assert get_sector_containing_orbit(9) == 1
     assert get_sector_containing_orbit(10) == 1
     assert get_sector_containing_orbit(11) == 2
-    assert get_sector_containing_orbit(197) == 95
-    assert get_sector_containing_orbit(198) == 95
+    assert get_sector_containing_orbit(199) == 96
+    assert get_sector_containing_orbit(200) == 96
+    # 4-orbit sectors
+    assert get_sector_containing_orbit(201) == 97
+    assert get_sector_containing_orbit(204) == 97
+    assert get_sector_containing_orbit(205) == 98
+    assert get_sector_containing_orbit(208) == 98
+    # Back to 2-orbit sectors
+    assert get_sector_containing_orbit(209) == 99
+    assert get_sector_containing_orbit(211) == 100
+    assert get_sector_containing_orbit(225) == 107
+    assert get_sector_containing_orbit(226) == 107
 
 
-@pytest.mark.parametrize("bad_orbit", [0, -1, 1, 8, 199, 300])
+@pytest.mark.parametrize("bad_orbit", [0, -1, 1, 8, 227, 300])
 def test_get_sector_containing_orbit_with_invalid_orbit(bad_orbit: int):
     with pytest.raises(ValueError):
         get_sector_containing_orbit(bad_orbit)
@@ -81,16 +91,31 @@ def test_get_sector_containing_orbit_with_invalid_orbit(bad_orbit: int):
 def test_get_orbits_in_sector():
     assert get_orbits_in_sector(1) == [9, 10]
     assert get_orbits_in_sector(2) == [11, 12]
-    assert get_orbits_in_sector(95) == [197, 198]
+    assert get_orbits_in_sector(96) == [199, 200]
+    assert get_orbits_in_sector(97) == [201, 202, 203, 204]
+    assert get_orbits_in_sector(98) == [205, 206, 207, 208]
+    assert get_orbits_in_sector(99) == [209, 210]
+    assert get_orbits_in_sector(107) == [225, 226]
 
 
-@pytest.mark.parametrize("bad_sector", [0, -1, 96, 150])
+@pytest.mark.parametrize("bad_sector", [0, -1, 108, 150])
 def test_get_orbits_in_sector_with_invalid_sector(bad_sector: int):
     with pytest.raises(ValueError):
         get_orbits_in_sector(bad_sector)
 
 
-@pytest.mark.parametrize(["sector", "orbits"], [(1, [9, 10]), (2, [11, 12]), (95, [197, 198])])
+@pytest.mark.parametrize(
+    ["sector", "orbits"],
+    [
+        (1, [9, 10]),
+        (2, [11, 12]),
+        (96, [199, 200]),
+        (97, [201, 202, 203, 204]),
+        (98, [205, 206, 207, 208]),
+        (99, [209, 210]),
+        (107, [225, 226]),
+    ],
+)
 def test_orbits_sector_round_trip(sector: int, orbits: list[int]):
     for orbit in get_orbits_in_sector(sector):
         assert get_sector_containing_orbit(orbit) == sector

--- a/tglc/utils/constants.py
+++ b/tglc/utils/constants.py
@@ -74,16 +74,28 @@ def get_exposure_time_from_sector(sector: int) -> u.Quantity:
 
 def get_sector_containing_orbit(orbit: int) -> int:
     """Get the TESS sector containing a TESS orbit."""
-    if 9 <= orbit <= 198:
+    if 9 <= orbit <= 200:
         return (orbit - 7) // 2
+    elif 201 <= orbit <= 204:
+        return 97
+    elif 205 <= orbit <= 208:
+        return 98
+    elif 209 <= orbit <= 226:
+        return (orbit - 11) // 2
     else:
         raise ValueError(f"Sector not known for orbit {orbit}")
 
 
 def get_orbits_in_sector(sector: int) -> list[int]:
     """Get the TESS orbits in a TESS sector."""
-    if 1 <= sector <= 95:
+    if 1 <= sector <= 96:
         return [sector * 2 + 7, sector * 2 + 8]
+    elif sector == 97:
+        return [sector * 2 + 7, sector * 2 + 8, sector * 2 + 9, sector * 2 + 10]
+    elif sector == 98:
+        return [sector * 2 + 9, sector * 2 + 10, sector * 2 + 11, sector * 2 + 12]
+    elif 99 <= sector <= 107:
+        return [sector * 2 + 11, sector * 2 + 12]
     else:
         raise ValueError(f"Orbits not known for sector {sector}")
 


### PR DESCRIPTION
These changes add the year 8 sector/orbit mappings based on the planned TESS observations for the start of EM3. This includes two sectors with 4 orbits (sectors 97, 98), with the remainder being normal, 2-orbit sectors. See <https://tess.mit.edu/tess-year-8-observations/> for reference.

As a note for future work: when changing this mapping, it is important to also change the unit tests that check that the sector/orbit mapping logic is correct. When new sectors are added, the tests should include the first and last of the new sectors as test cases. Refer to the changes here for an example of how to add these, and run `pytest` before merging to main!