### PR TITLE
WIP: Hotfix/psql parameter limit

### DIFF
--- a/tglc/databases.py
+++ b/tglc/databases.py
@@ -43,23 +43,34 @@ class Database:
 
         return r_table, left_col == right_col
 
-    def by_id(self, tablename: str, id: typing.Any):
+    def by_id(
+        self,
+        tablename: str,
+        id: str | int | typing.Iterable[str | int],
+    ) -> sa.sql.elements.ColumnElement:
+        """Create WHERE clause for matching by primary key using ANY clause."""
         table = self.table(tablename)
-
-        # For now, no composite primary keys are allowed
         columns = tuple(table.primary_key.columns)
 
-        if len(columns) == 1:
-            if isinstance(id, str):
-                return columns[0] == id
-            try:
-                ids = list(id)
-                return columns[0].in_(ids)
-            except TypeError:
-                return columns[0] == id
-        else:
-            # Not supporting composite primary keys yet
-            raise NotImplementedError
+        if len(columns) != 1:
+            raise NotImplementedError("Composite primary keys are not supported")
+
+        column = columns[0]
+
+        if isinstance(id, str):
+            return column == id
+
+        try:
+            ids = id.tolist() if hasattr(id, "tolist") else list(id)
+        except TypeError:
+            return column == id
+
+        if len(ids) == 0:
+            return sa.false()
+        if len(ids) == 1:
+            return column == ids[0]
+
+        return column == sa.any_(ids)
 
     def execute(self, query):
         with self.Session() as db:

--- a/tglc/scripts/catalogs.py
+++ b/tglc/scripts/catalogs.py
@@ -85,21 +85,19 @@ def _run_tic_cone_query(
     tic_with_gaia_dr2 = pd.DataFrame(
         tic_cone_query_results, columns=[field.lower() for field in TIC_CATALOG_FIELDS]
     )
-    non_null_gaia_dr2_source_ids = tic_with_gaia_dr2["gaia"].dropna().astype(int)
+    non_null_gaia_dr2_source_ids = tic_with_gaia_dr2["gaia"].dropna().astype(int).tolist()
 
     logger.debug(f"Querying Gaia DR2 to DR3 table for stars around {ra=:.2f}, {dec=:.2f}")
-    # Note: using `.in_` makes each source ID a separate parameter in SQLAlchemy's query
-    # construction. There is a maximum number of query parameters, which is not hit by 5deg cone
-    # queries, but if those queries ever get larger, `.in_` will break. In that case, `sa.any_`
-    # should be used instead, as in the following snipet:
-    # gaia_match_query = tic.select("dr2_to_dr3", "dr2_source_id", "dr3_source_id").where(
-    #     dr2_to_dr3.c.dr2_source_id == sa.any_(non_null_gaia_dr2_source_ids)
-    # )
-    gaia_match_query = tic.select("dr2_to_dr3", "dr2_source_id", "dr3_source_id").where(
-        dr2_to_dr3.c.dr2_source_id.in_(non_null_gaia_dr2_source_ids)
-    )
-    gaia_match_query_results = tic.execute(gaia_match_query)
-    gaia_match = pd.DataFrame(gaia_match_query_results, columns=["dr2_source_id", "dr3_source_id"])
+
+    if len(non_null_gaia_dr2_source_ids) == 0:
+        gaia_match = pd.DataFrame(columns=["dr2_source_id", "dr3_source_id"])
+    else:
+        # Use ANY clause instead of IN to avoid PostgreSQL's parameter limit
+        gaia_match_query = tic.select("dr2_to_dr3", "dr2_source_id", "dr3_source_id").where(
+            dr2_to_dr3.c.dr2_source_id == sa.any_(non_null_gaia_dr2_source_ids)
+        )
+        gaia_match_query_results = tic.execute(gaia_match_query)
+        gaia_match = pd.DataFrame(gaia_match_query_results, columns=["dr2_source_id", "dr3_source_id"])
     gaia_match["dr2_source_id"] = gaia_match["dr2_source_id"].astype(str)
     gaia_match["dr3_source_id"] = pd.array(gaia_match["dr3_source_id"]).astype("Int64")
 


### PR DESCRIPTION
This pull request improves how primary key queries are constructed in the database layer and updates the handling of large lists of IDs in catalog queries. The main focus is to use PostgreSQL's ANY clause instead of IN to avoid hitting parameter limits, and to make the code more robust and explicit about unsupported composite primary keys.

**Database query improvements:**

* Updated the `by_id` method in `tglc/databases.py` to support both single and multiple primary key values, using the `ANY` clause for lists of IDs, and added explicit error handling for unsupported composite primary keys.

**Catalog query robustness:**

* Modified `_run_tic_cone_query` in `tglc/scripts/catalogs.py` to convert the list of Gaia DR2/DR3 source IDs to a Python list and use the `ANY` clause in SQL queries, preventing issues with PostgreSQL's parameter limit for large ID lists. Also, added a check to return an empty DataFrame if the list of IDs is empty.