### PR TITLE
moving from IN clause to ANY clause to bypass 2^16 parameter limit

### DIFF
--- a/tglc/scripts/catalogs.py
+++ b/tglc/scripts/catalogs.py
@@ -88,15 +88,8 @@ def _run_tic_cone_query(
     non_null_gaia_dr2_source_ids = tic_with_gaia_dr2["gaia"].dropna().astype(int)
 
     logger.debug(f"Querying Gaia DR2 to DR3 table for stars around {ra=:.2f}, {dec=:.2f}")
-    # Note: using `.in_` makes each source ID a separate parameter in SQLAlchemy's query
-    # construction. There is a maximum number of query parameters, which is not hit by 5deg cone
-    # queries, but if those queries ever get larger, `.in_` will break. In that case, `sa.any_`
-    # should be used instead, as in the following snipet:
-    # gaia_match_query = tic.select("dr2_to_dr3", "dr2_source_id", "dr3_source_id").where(
-    #     dr2_to_dr3.c.dr2_source_id == sa.any_(non_null_gaia_dr2_source_ids)
-    # )
     gaia_match_query = tic.select("dr2_to_dr3", "dr2_source_id", "dr3_source_id").where(
-        dr2_to_dr3.c.dr2_source_id.in_(non_null_gaia_dr2_source_ids)
+        dr2_to_dr3.c.dr2_source_id == sa.any_(non_null_gaia_dr2_source_ids.tolist())
     )
     gaia_match_query_results = tic.execute(gaia_match_query)
     gaia_match = pd.DataFrame(gaia_match_query_results, columns=["dr2_source_id", "dr3_source_id"])


### PR DESCRIPTION
Moving SQL ANY clause from IN to bypass psycopg's 2^16 parameter limit. This allows us to process crowded fields without issue.